### PR TITLE
Update pipeline.json

### DIFF
--- a/11 - Dynamic ADF/pipeline.json
+++ b/11 - Dynamic ADF/pipeline.json
@@ -121,7 +121,7 @@
                                     "type": "DatasetReference",
                                     "parameters": {
                                         "serverName": {
-                                            "value": "@pipeline().parameters.serverName",
+                                            "value": "@replace(pipeline().parameters.serverName, '.','-')",
                                             "type": "Expression"
                                         },
                                         "databaseName": {


### PR DESCRIPTION
The data lake naming convention does not allow full stop '.' in file names. As a result the copy activity of the pipeline fails with the below example error message. 

ErrorCode=AdlsGen2InvalidResourceName,'Type=Microsoft.DataTransfer.Common.Shared.HybridDeliveryException,Message=The specified container name 'adfsqlserver2.database.windows.net' contains invalid characters. Refer to container naming rules: https://learn.microsoft.com/rest/api/storageservices/naming-and-referencing-containers--blobs--and-metadata,Source=Microsoft.DataTransfer.ClientLibrary,''Type=Microsoft.Azure.Storage.Data.Models.ErrorSchemaException,Message=Operation returned an invalid status code 'BadRequest',Source=Microsoft.DataTransfer.ClientLibrary,'

The proposed change replaces full stops with hyphen '-'. The pipeline executes fine after this change.